### PR TITLE
Use method with chaining and multiple functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ module.exports = class CoMws {
     this.mws = [];
   }
 
-  use(mw) {
-    this.mws.push(mw);
-
+  use(...mw) {
+    this.mws.push(...mw);
+    return this;
   }
 
   handleError(ctx, err, mwIdx) {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,12 @@ module.exports = class CoMws {
     this.mws = [];
   }
 
-  use(...mw) {
-    this.mws.push(...mw);
+  use(mw) {
+    if (arguments.length === 1) {
+      this.mws.push(mw)
+    } else {
+      this.mws.push.apply(this.mws, Array.from(arguments))
+    }
     return this;
   }
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ module.exports = class CoMws {
 
   use(mw) {
     if (arguments.length === 1) {
-      this.mws.push(mw)
+      this.mws.push(mw);
     } else {
-      this.mws.push.apply(this.mws, Array.from(arguments))
+      this.mws.push.apply(this.mws, Array.from(arguments));
     }
     return this;
   }


### PR DESCRIPTION
Very little change, but also tremendously helpful. With this you can chain like `use(fn1).use(fn2)` or specify all functions at once `use(fn1, fn2)`. Later is especially useful if list of middleware is dynamically assembled.